### PR TITLE
fix: Head component `http-equiv` attribute typo

### DIFF
--- a/src/lib/components/Head.svelte
+++ b/src/lib/components/Head.svelte
@@ -4,6 +4,6 @@
 </script>
 
 <head {...$$restProps}>
-	<meta httpEquiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<slot />
 </head>


### PR DESCRIPTION
This PR fixes the meta tag inserted by the `Head` component to be

```html
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
```

Fixing the typo `httpEquiv`