### PR TITLE
Fix main/module/exports for "."

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"default": "./dist/index.js"
 		},
 		"./package.json": {
 			"default": "./package.json"


### PR DESCRIPTION
When I lunch tests with `vitest 3`, I get this error: 

```
Error: Failed to resolve entry for package "svelty-email". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "svelty-email" package
```

I have a pnpm patch localy to have it working, but maybe it's better to give it to everyone :)